### PR TITLE
Prevent calling setState on an unmounted component

### DIFF
--- a/src/Stagger.js
+++ b/src/Stagger.js
@@ -26,7 +26,7 @@ export default class Stagger extends React.Component {
   }
 
   componentWillUnmount() {
-    clearInterval(this.timeout);
+    clearTimeout(this.timeout);
   }
 
   addItem() {

--- a/src/Stagger.js
+++ b/src/Stagger.js
@@ -25,6 +25,10 @@ export default class Stagger extends React.Component {
     this.timeout = setTimeout(this.addItem, this.props.initialDelay);
   }
 
+  componentWillUnmount() {
+    clearInterval(this.timeout);
+  }
+
   addItem() {
     if (this.itemsAdded < this.props.children.length) {
       this.setState({


### PR DESCRIPTION
I had a warning in console because of calling setState on an unmounted component. You can see it in the .gif below. 

![stagger-bug](https://user-images.githubusercontent.com/4049739/34393136-6411f9f0-eb61-11e7-9d18-f35ccfd6ad4a.gif)

Repo with example: [https://github.com/romankrru/react-css-stagger-test](https://github.com/romankrru/react-css-stagger-test)